### PR TITLE
Adjust knob hue range

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,8 +685,8 @@
                 const knobImage = document.getElementById(elementId);
                 if (!knobImage) return;
                 const value = parseFloat(percentage) / 100; 
-                const hueMinDeg = 180; 
-                const hueMaxDeg = 280; 
+                const hueMinDeg = 180;
+                const hueMaxDeg = 330; // extend range into mauve/red-purple
                 const targetHue = hueMinDeg + (hueMaxDeg - hueMinDeg) * value;
                 const brightness = 0.8 + 0.4 * value;
                 knobImage.style.filter = `hue-rotate(${targetHue}deg) saturate(1.5) brightness(${brightness})`;


### PR DESCRIPTION
## Summary
- tweak the knob hue range so it transitions from cyan to mauve/purple without veering toward green

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f81e869748325b2cd4fa8435e5c29