### PR TITLE
Add ad banner linking to AI page

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,5 +872,10 @@
             }
         });
     </script>
+    <div style="text-align:center; margin-top:20px;">
+        <a href="https://mikewhyle.com/ai/" target="_blank">
+            <img src="ad-mikewhyle-ai-consultant.png" alt="AI Consultant" style="max-width:100%; height:auto;">
+        </a>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include advertisement banner at the bottom of `index.html`
- make banner link to https://mikewhyle.com/ai/

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68868375656883258e5aeec69d857120