### PR TITLE
Fix audio setup strict-mode reference error

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,8 +596,6 @@
       channel.panLFOA.start();
       channel.panLFOB.start();
 
-      srcConnect = (src, pre, cross, panner) => src.connect(pre).connect(cross).connect(panner);
-
       channel.pannerA.connect(channel.sum);
       channel.pannerB.connect(channel.sum);
 


### PR DESCRIPTION
## Summary
- remove the stray srcConnect assignment that threw a ReferenceError during channel setup so sounds can load again

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1e55c8e2c8325961c3d7db6fc0a8a