### PR TITLE
Improve SLUMBR responsiveness and loading behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,12 @@
     *{ margin:0; padding:0; box-sizing:border-box; }
     body{
       font-family:Arial, sans-serif;
-      background:#0f1220;
+      background:#0f1220 url('backgroundlatest.png') center/cover fixed;
       color:white;
       user-select:none;
       overflow-x:hidden;
       overflow-y:auto;
-      min-height:100vh;
+      min-height:100dvh;
       padding:0 12px 32px;
       position:relative;
     }
@@ -37,9 +37,9 @@
 
     .layer-switcher{
       position:absolute;
-      top:10%;
+      top:12%;
       left:50%;
-      transform:translate(-50%, -50%);
+      transform:translateX(-50%);
       display:flex;
       gap:10px;
       z-index:25;
@@ -64,7 +64,7 @@
 
     .layer-surface{
       position:relative; width:100%; height:100%;
-      background-image:url('background.png'); background-size:100% 100%; background-position:center top; background-repeat:no-repeat;
+      background-image:url('background.png'); background-size:cover; background-position:center top; background-repeat:no-repeat;
       background-color:#070912;
     }
 
@@ -73,8 +73,8 @@
     }
 
     .layer-badge{
-      position:absolute; top:22px; left:26px; background:rgba(0,0,0,0.45); padding:4px 10px; border-radius:999px;
-      font-size:10px; letter-spacing:0.08em; text-transform:uppercase; opacity:0.7; pointer-events:none;
+      position:absolute; top:26px; left:26px; background:rgba(0,0,0,0.45); padding:3px 8px; border-radius:999px;
+      font-size:9px; letter-spacing:0.12em; text-transform:uppercase; opacity:0.7; pointer-events:none;
     }
 
     .tintOverlay{
@@ -187,11 +187,11 @@
 
     .channel.sky{ left:28%; top:56%; }
     .channel.fire{ left:72%; top:56%; }
-    .channel.earth{ left:28%; top:83%; }
-    .channel.sea{ left:72%; top:83%; }
-    .control-knob.astral{ left:38%; top:30%; }
-    .control-knob.lucid{ left:62%; top:30%; }
-    .control-knob.master{ left:50%; top:66%; }
+    .channel.earth{ left:28%; top:86%; }
+    .channel.sea{ left:72%; top:86%; }
+    .control-knob.astral{ left:38%; top:32%; }
+    .control-knob.lucid{ left:62%; top:32%; }
+    .control-knob.master{ left:50%; top:69%; }
 
     .channel-content{ display:flex; flex-direction:column; align-items:center; justify-content:center; gap:4px; width:100%; }
     .channel.earth .channel-content > .channel-spinner,
@@ -240,6 +240,16 @@
     .layer-theme-green .layer-surface{ filter:hue-rotate(28deg) saturate(1.05); }
     .layer-theme-red .layer-surface{ filter:hue-rotate(-58deg) saturate(1.12); }
 
+    @media (max-width:720px){
+      body{ background-attachment:scroll; }
+      .layer-switcher{ top:14%; }
+      .channel.sky{ top:58%; left:26%; }
+      .channel.fire{ top:58%; left:74%; }
+      .channel.earth{ top:89%; left:26%; }
+      .channel.sea{ top:89%; left:74%; }
+      .control-knob.master{ top:72%; }
+    }
+
     @media (max-width:560px){
       body{ padding:0 6px 24px; }
       .app-container{
@@ -248,13 +258,13 @@
         margin:clamp(8px, 4vh, 20px) auto;
         max-height:none;
       }
-      .layer-switcher{ top:12%; }
+      .layer-switcher{ top:16%; }
       .channel{ width:min(24vw, 110px); }
-      .channel.sky{ left:27%; top:58%; }
-      .channel.fire{ left:73%; top:58%; }
-      .channel.earth{ left:27%; top:86%; }
-      .channel.sea{ left:73%; top:86%; }
-      .control-knob.master{ top:70%; }
+      .channel.sky{ left:28%; top:60%; }
+      .channel.fire{ left:72%; top:60%; }
+      .channel.earth{ left:28%; top:92%; }
+      .channel.sea{ left:72%; top:92%; }
+      .control-knob.master{ top:74%; }
     }
 
     .hint-overlay{ position:fixed; inset:0; display:none; align-items:center; justify-content:center; pointer-events:none; z-index:300; }
@@ -816,6 +826,7 @@
           }finally{
             done++;
             this.updateLoadingProgress(done, totalCore);
+            await this.waitForIdle();
           }
         }
       }
@@ -855,6 +866,7 @@
           }finally{
             this.lazyLoadDone = Math.min(this.lazyLoadTotal, this.lazyLoadDone + 1);
             this.toggleLazyStatus(true, this.lazyLoadDone, this.lazyLoadTotal);
+            await this.waitForIdle();
           }
         }
       }
@@ -879,6 +891,13 @@
       status.hidden = false;
       status.style.display = 'inline-flex';
       status.textContent = `Loading extended library… ${done}/${total} (${pct}%)`;
+    }
+
+    waitForIdle(){
+      if(typeof window !== 'undefined' && 'requestIdleCallback' in window){
+        return new Promise(resolve=> requestIdleCallback(()=> resolve(), { timeout:180 }));
+      }
+      return new Promise(resolve=> setTimeout(resolve, 32));
     }
 
     markSoundLoaded(channelName, index, meta){

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'slumbr-v3';
+const CACHE_NAME = 'slumbr-v4';
 const PRECACHE_ASSETS = [
   './',
   './index.html',
@@ -43,7 +43,7 @@ self.addEventListener('fetch', event => {
 
   if(request.mode === 'navigate'){
     event.respondWith(
-      fetch(request)
+      fetch(new Request(request, { cache: 'no-store' }))
         .then(response => {
           const copy = response.clone();
           caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
@@ -55,6 +55,19 @@ self.addEventListener('fetch', event => {
   }
 
   if(url.origin === location.origin){
+    if(url.pathname === '/' || url.pathname.endsWith('/index.html')){
+      event.respondWith(
+        fetch(new Request(request, { cache: 'no-store' }))
+          .then(networkResp => {
+            const copy = networkResp.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+            return networkResp;
+          })
+          .catch(()=> caches.match(request))
+      );
+      return;
+    }
+
     if(url.pathname.startsWith('/sounds/')){
       event.respondWith(
         caches.match(request).then(resp => resp || fetch(request))


### PR DESCRIPTION
## Summary
- refresh background and layout styling for better desktop coverage and responsive knob placement
- throttle audio preload work to avoid blocking the UI while lazy loading remaining sounds
- update the service worker caching strategy to prefer fresh HTML and bust old caches

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68db0ce1b618832583781216a05f4062