### PR TITLE
Ensure SLUMBR controls scale within the viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,11 +414,46 @@
   <script>
     (function(){
       const BASE_WIDTH = 540;
+      const BASE_HEIGHT = 835;
+      const MAX_WIDTH = 580;
+      const VIEWPORT_WIDTH_RATIO = 0.94;
+
+      const parseFloatOrZero = value => {
+        const result = parseFloat(value);
+        return Number.isFinite(result) ? result : 0;
+      };
+
       const updateScale = ()=>{
+        const viewportWidth = document.documentElement?.clientWidth || window.innerWidth;
+        const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+        const bodyStyles = window.getComputedStyle(document.body);
+        const bodyPaddingX = parseFloatOrZero(bodyStyles.paddingLeft) + parseFloatOrZero(bodyStyles.paddingRight);
+        const bodyPaddingY = parseFloatOrZero(bodyStyles.paddingTop) + parseFloatOrZero(bodyStyles.paddingBottom);
+
         document.querySelectorAll('.app-container').forEach(container=>{
-          const width = container.clientWidth;
-          if(!width) return;
-          const scale = width / BASE_WIDTH;
+          const containerStyles = window.getComputedStyle(container);
+          const marginTop = parseFloatOrZero(containerStyles.marginTop);
+          const marginBottom = parseFloatOrZero(containerStyles.marginBottom);
+
+          const availableWidth = Math.max(0,
+            Math.min(
+              MAX_WIDTH,
+              viewportWidth * VIEWPORT_WIDTH_RATIO,
+              viewportWidth - bodyPaddingX
+            )
+          );
+
+          const availableHeightRaw = viewportHeight - marginTop - marginBottom - bodyPaddingY;
+          const scaleFromWidth = availableWidth > 0 ? (availableWidth / BASE_WIDTH) : 1;
+          const scaleFromHeight = availableHeightRaw > 0 ? (availableHeightRaw / BASE_HEIGHT) : scaleFromWidth;
+          const rawScale = Math.min(scaleFromWidth, scaleFromHeight);
+          const scale = rawScale > 0 && Number.isFinite(rawScale) ? rawScale : 1;
+
+          const targetWidth = BASE_WIDTH * scale;
+          const targetHeight = BASE_HEIGHT * scale;
+
+          container.style.width = `${targetWidth}px`;
+          container.style.height = `${targetHeight}px`;
           container.style.setProperty('--layer-scale', scale.toFixed(4));
         });
       };
@@ -428,6 +463,9 @@
         document.querySelectorAll('.app-container').forEach(container=>resizeObserver.observe(container));
       }
       window.addEventListener('resize', updateScale, { passive:true });
+      if(window.visualViewport){
+        window.visualViewport.addEventListener('resize', updateScale, { passive:true });
+      }
       updateScale();
     })();
   </script>


### PR DESCRIPTION
## Summary
- compute scaling using both viewport width and height so the layout shrinks instead of clipping when space is limited
- update the app container dimensions and listen for visual viewport changes to keep controls accessible during zooming

## Testing
- Manual verification via Playwright screenshots

------
https://chatgpt.com/codex/tasks/task_e_68dbb6ef6f788325abbc229b01393e11