### PR TITLE
Improve responsive layout and audio initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,39 +17,46 @@
       background:#0f1220 url('backgroundlatest.png') center/cover fixed;
       color:white;
       user-select:none;
-      overflow:hidden;
-      min-height:100vh;
+      overflow-x:hidden;
+      overflow-y:auto;
+      min-height:100dvh;
       height:100%;
       display:flex;
       flex-direction:column;
       align-items:center;
       justify-content:center;
-      padding:clamp(16px, 6vh, 48px) clamp(14px, 6vw, 40px);
+      gap:clamp(16px, 3vh, 32px);
+      padding:calc(max(env(safe-area-inset-top, 0px), clamp(16px, 6vh, 48px))) clamp(14px, 6vw, 40px) clamp(max(env(safe-area-inset-bottom, 0px), clamp(16px, 5vh, 48px)));
       position:relative;
     }
 
     .app-container{
       position:relative;
-      width:min(580px, 94vw, calc((100vh - 96px) * 540 / 835));
+      width:min(620px, 96vw);
       aspect-ratio:540 / 835;
       height:auto;
       margin:0 auto;
-      max-height:calc(100vh - 96px);
       --layer-scale:1;
       flex:0 0 auto;
     }
     @supports not (aspect-ratio: 1){
-      .app-container{ height:835px; }
+      .app-container{ height:835px; width:540px; }
     }
 
     .layer-switcher{
       position:absolute;
-      top:calc(var(--layer-scale) * 100px);
+      top:clamp(18px, var(--layer-scale) * 72px, 84px);
       left:50%;
       transform:translateX(-50%);
       display:flex;
-      gap:calc(var(--layer-scale) * 10px);
-      z-index:25;
+      gap:clamp(8px, var(--layer-scale) * 12px, 14px);
+      padding:6px 12px;
+      background:rgba(8,12,32,0.55);
+      border:1px solid rgba(255,255,255,0.18);
+      border-radius:999px;
+      box-shadow:0 8px 28px rgba(0,0,0,0.35);
+      z-index:35;
+      backdrop-filter:blur(6px);
     }
     .layer-dot{
       width:calc(var(--layer-scale) * 14px); height:calc(var(--layer-scale) * 14px); border-radius:50%; border:1px solid rgba(255,255,255,0.5);
@@ -65,14 +72,23 @@
     .layer-dot.active::after{ opacity:1; background:rgba(255,255,255,0.7); }
     .layer-dot:hover{ transform:scale(1.08); }
 
-    .layer-stack{ position:absolute; inset:0; border-radius:12px; overflow:hidden; }
+    .layer-stack{ position:absolute; inset:0; border-radius:18px; overflow:hidden; box-shadow:0 28px 60px rgba(0,0,0,0.45); }
     .slumbr-layer{ position:absolute; inset:0; display:none; }
     .slumbr-layer.is-active{ display:block; }
 
     .layer-surface{
-      position:relative; width:100%; height:100%;
-      background-image:url('background.png'); background-size:100% 100%; background-position:center top; background-repeat:no-repeat;
+      position:relative;
+      width:100%;
+      height:100%;
+      background-image:url('background.png');
+      background-size:100% 100%;
+      background-position:center top;
+      background-repeat:no-repeat;
       background-color:#070912;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:clamp(20px, var(--layer-scale) * 36px, 48px);
     }
 
     .layer-surface::after{
@@ -80,8 +96,18 @@
     }
 
     .layer-badge{
-      position:absolute; top:calc(var(--layer-scale) * 26px); left:calc(var(--layer-scale) * 26px); background:rgba(0,0,0,0.45); padding:calc(var(--layer-scale) * 3px) calc(var(--layer-scale) * 8px); border-radius:999px;
-      font-size:clamp(7px, var(--layer-scale) * 9px, 9px); letter-spacing:0.12em; text-transform:uppercase; opacity:0.7; pointer-events:none;
+      position:absolute;
+      top:calc(var(--layer-scale) * 26px);
+      left:calc(var(--layer-scale) * 26px);
+      background:rgba(5,8,20,0.65);
+      padding:calc(var(--layer-scale) * 4px) calc(var(--layer-scale) * 10px);
+      border-radius:999px;
+      font-size:clamp(8px, var(--layer-scale) * 10px, 11px);
+      letter-spacing:0.14em;
+      text-transform:uppercase;
+      opacity:0.75;
+      pointer-events:none;
+      backdrop-filter:blur(3px);
     }
 
     .tintOverlay{
@@ -92,19 +118,53 @@
       border-radius:12px;
     }
 
-    .channel{
-      position:absolute;
+    .console-grid{
+      position:relative;
+      display:grid;
+      grid-template-columns:repeat(2, minmax(0, 1fr));
+      grid-template-areas:
+        "astral lucid"
+        "sky fire"
+        "master master"
+        "earth sea"
+        "eq eq"
+        "lazy lazy"
+        "actions actions";
+      gap:clamp(12px, var(--layer-scale) * 24px, 34px);
+      width:100%;
+      height:100%;
+      align-items:center;
+      justify-items:center;
+    }
+
+    .channel,
+    .control-knob{
+      position:relative;
+      transform:none;
+      left:auto;
+      top:auto;
       display:flex;
       flex-direction:column;
       align-items:center;
-      width:calc(var(--layer-scale) * 110px);
-      max-width:none;
-      height:calc(var(--layer-scale) * 240px);
-      padding:calc(var(--layer-scale) * 4px);
-      transform:translate(-50%, -50%);
-      left:calc(var(--pos-x, 0px) * var(--layer-scale));
-      top:calc(var(--pos-y, 0px) * var(--layer-scale));
+      justify-content:center;
+      gap:calc(var(--layer-scale) * 8px);
+      width:100%;
+      max-width:calc(var(--layer-scale) * 220px);
+      padding:0;
+      justify-self:center;
+      text-align:center;
     }
+
+    .control-knob.astral{ grid-area:astral; }
+    .control-knob.lucid{ grid-area:lucid; }
+    .control-knob.master{ grid-area:master; }
+    .channel.sky{ grid-area:sky; }
+    .channel.fire{ grid-area:fire; }
+    .channel.earth{ grid-area:earth; }
+    .channel.sea{ grid-area:sea; }
+
+    .channel-content{ display:flex; flex-direction:column; align-items:center; justify-content:center; gap:calc(var(--layer-scale) * 8px); width:100%; }
+
     .knob-container{ position:relative; width:calc(var(--layer-scale) * 75px); height:calc(var(--layer-scale) * 75px); cursor:grab; }
     .knob-container.dragging{ cursor:grabbing; }
     .knob-slider{ position:absolute; width:100%; height:100%; opacity:0; cursor:pointer; z-index:2; margin:0; }
@@ -113,33 +173,44 @@
       pointer-events:none; filter:hue-rotate(180deg) saturate(1.5); transition:filter 0.1s ease, transform 0.08s ease-out;
       transform:rotate(-135deg);
     }
-    .knob-readout{ width:calc(var(--layer-scale) * 75px); height:calc(var(--layer-scale) * 24px); text-align:center; font-size:clamp(10px, var(--layer-scale) * 12px, 13px); color:white; line-height:calc(var(--layer-scale) * 24px); margin-top:calc(var(--layer-scale) * 2px); }
+    .knob-readout{ width:calc(var(--layer-scale) * 90px); height:calc(var(--layer-scale) * 24px); text-align:center; font-size:clamp(11px, var(--layer-scale) * 12px, 13px); color:white; line-height:calc(var(--layer-scale) * 24px); margin-top:calc(var(--layer-scale) * 2px); }
+
+    .control-knob.small .knob-container{ width:calc(var(--layer-scale) * 58px); height:calc(var(--layer-scale) * 58px); }
+    .control-knob.small .knob-readout{ width:calc(var(--layer-scale) * 72px); font-size:clamp(10px, var(--layer-scale) * 11px, 12px); height:calc(var(--layer-scale) * 20px); line-height:calc(var(--layer-scale) * 20px); margin-top:calc(var(--layer-scale) * 2px); }
+    .control-knob.large .knob-container{ width:calc(var(--layer-scale) * 160px); height:calc(var(--layer-scale) * 160px); cursor:grab; }
+    .control-knob.large .knob-readout{ width:calc(var(--layer-scale) * 180px); font-size:clamp(12px, var(--layer-scale) * 14px,14px); height:calc(var(--layer-scale) * 26px); line-height:calc(var(--layer-scale) * 26px); margin-top:calc(var(--layer-scale) * 4px); }
 
     .channel-spinner{
-      width:calc(var(--layer-scale) * 90px); height:calc(var(--layer-scale) * 36px); background:transparent; border:1.5px solid rgba(58,137,255,0.4); border-radius:calc(var(--layer-scale) * 8px);
-      color:white; font-size:clamp(12px, var(--layer-scale) * 16px, 16px); text-align:center; text-align-last:center; cursor:pointer; padding:0 calc(var(--layer-scale) * 4px);
-      -webkit-appearance:none; -moz-appearance:none; appearance:none;
+      width:100%;
+      max-width:calc(var(--layer-scale) * 190px);
+      height:calc(var(--layer-scale) * 38px);
+      background:rgba(9,14,28,0.65);
+      border:1.5px solid rgba(58,137,255,0.35);
+      border-radius:calc(var(--layer-scale) * 12px);
+      color:white;
+      font-size:clamp(12px, var(--layer-scale) * 15px, 16px);
+      text-align:center;
+      text-align-last:center;
+      cursor:pointer;
+      padding:0 calc(var(--layer-scale) * 8px);
+      -webkit-appearance:none;
+      -moz-appearance:none;
+      appearance:none;
+      box-shadow:0 10px 24px rgba(0,0,0,0.25);
     }
     .channel-spinner:focus{ outline:none; border-color:rgba(58,137,255,0.8); }
-    select.channel-spinner option{ background:#1f1f3d; color:white; font-size:clamp(12px, var(--layer-scale) * 16px, 16px); }
+    select.channel-spinner option{ background:#1f1f3d; color:white; font-size:clamp(12px, var(--layer-scale) * 15px, 16px); }
     select.channel-spinner option:hover{ background:#3c3c5d; }
 
-    .control-knob{ position:absolute; display:flex; flex-direction:column; align-items:center; transform:translate(-50%, -50%);
-      left:calc(var(--pos-x, 0px) * var(--layer-scale)); top:calc(var(--pos-y, 0px) * var(--layer-scale)); }
-    .control-knob.small .knob-container{ width:calc(var(--layer-scale) * 50px); height:calc(var(--layer-scale) * 50px); }
-    .control-knob.small .knob-readout{ width:calc(var(--layer-scale) * 50px); font-size:clamp(9px, var(--layer-scale) * 10px, 11px); height:calc(var(--layer-scale) * 18px); line-height:calc(var(--layer-scale) * 18px); margin-top:calc(var(--layer-scale) * 2px); }
-    .control-knob.large .knob-container{ width:calc(var(--layer-scale) * 150px); height:calc(var(--layer-scale) * 150px); cursor:grab; }
-    .control-knob.large .knob-readout{ width:calc(var(--layer-scale) * 150px); font-size:clamp(12px, var(--layer-scale) * 14px, 14px); height:calc(var(--layer-scale) * 24px); line-height:calc(var(--layer-scale) * 24px); margin-top:calc(var(--layer-scale) * 2px); }
 
     .save-load-buttons{
-      position:absolute;
-      bottom:calc(var(--layer-scale) * 8px);
-      left:50%;
-      transform:translateX(-50%);
+      grid-area:actions;
+      position:relative;
       display:flex;
-      gap:calc(var(--layer-scale) * 16px);
+      gap:calc(var(--layer-scale) * 18px);
       align-items:center;
       justify-content:center;
+      width:100%;
     }
     .save-load-button{
       width:calc(var(--layer-scale) * 80px);
@@ -179,10 +250,22 @@
     .save-load-button.load{ background-image:url('load.png'); }
     .save-load-button.save{ background-image:url('save.png'); }
 
-    .eq-buttons{ position:absolute; bottom:calc(var(--layer-scale) * 100px); left:50%; transform:translateX(-50%); display:flex; gap:calc(var(--layer-scale) * 6px); align-items:center; justify-content:center; }
+    .eq-buttons{
+      grid-area:eq;
+      position:relative;
+      display:flex;
+      gap:calc(var(--layer-scale) * 10px);
+      align-items:center;
+      justify-content:center;
+      width:100%;
+    }
     .eq-button{
-      width:calc(var(--layer-scale) * 16px); height:calc(var(--layer-scale) * 16px); border-radius:50%;
-      border:1px solid rgba(255,255,255,0.5); background:transparent; cursor:pointer;
+      width:calc(var(--layer-scale) * 18px);
+      height:calc(var(--layer-scale) * 18px);
+      border-radius:50%;
+      border:1px solid rgba(255,255,255,0.45);
+      background:rgba(255,255,255,0.12);
+      cursor:pointer;
       box-shadow:0 0 0 0 rgba(0,0,0,0) inset;
       transition: box-shadow 0.2s ease, transform 0.05s ease;
     }
@@ -195,15 +278,6 @@
     .eq-brown{ background: rgba(165,94,41,0.32); }
     .eq-black{ background: rgba(20,24,30,0.55); }
 
-    .channel.sky{ --pos-x:152px; --pos-y:470px; }
-    .channel.fire{ --pos-x:388px; --pos-y:470px; }
-    .channel.earth{ --pos-x:152px; --pos-y:716px; }
-    .channel.sea{ --pos-x:388px; --pos-y:716px; }
-    .control-knob.astral{ --pos-x:205px; --pos-y:268px; }
-    .control-knob.lucid{ --pos-x:335px; --pos-y:268px; }
-    .control-knob.master{ --pos-x:270px; --pos-y:576px; }
-
-    .channel-content{ display:flex; flex-direction:column; align-items:center; justify-content:center; gap:calc(var(--layer-scale) * 4px); width:100%; }
     .channel.earth .channel-content > .channel-spinner,
     .channel.sea  .channel-content > .channel-spinner{ order:1; }
     .channel.earth .channel-content > .knob-container,
@@ -218,26 +292,39 @@
     .channel.fire .channel-content > .channel-spinner{ order:3; }
 
     .loading-indicator{
-      position:absolute; top:50%; left:50%; transform:translate(-50%,-50%);
-      color:white; font-size:clamp(14px, var(--layer-scale) * 18px, 18px); text-align:center; padding:calc(var(--layer-scale) * 20px); background-color:rgba(0,0,0,0.5); border-radius:calc(var(--layer-scale) * 8px);
+      position:absolute;
+      top:50%;
+      left:50%;
+      transform:translate(-50%,-50%);
+      color:white;
+      font-size:clamp(15px, var(--layer-scale) * 18px, 18px);
+      text-align:center;
+      padding:calc(var(--layer-scale) * 18px) calc(var(--layer-scale) * 28px);
+      background:rgba(8,12,24,0.82);
+      border:1px solid rgba(120,180,255,0.45);
+      border-radius:calc(var(--layer-scale) * 18px);
       cursor:pointer;
       touch-action:manipulation;
+      box-shadow:0 18px 38px rgba(0,0,0,0.35);
+      backdrop-filter:blur(6px);
+      min-width:calc(var(--layer-scale) * 220px);
     }
-    .progress{ margin-top:calc(var(--layer-scale) * 12px); width:calc(var(--layer-scale) * 260px); height:calc(var(--layer-scale) * 6px); background:rgba(255,255,255,0.15); border-radius:calc(var(--layer-scale) * 3px); overflow:hidden; }
+    .loading-indicator:focus-visible{ outline:2px solid rgba(120,180,255,0.9); outline-offset:4px; }
+    .progress{ margin-top:calc(var(--layer-scale) * 12px); width:calc(var(--layer-scale) * 260px); height:calc(var(--layer-scale) * 6px); background:rgba(255,255,255,0.12); border-radius:calc(var(--layer-scale) * 3px); overflow:hidden; }
     .progress-bar{ height:100%; width:0%; background:#2ecc71; transition:width 0.2s ease; }
 
     .lazy-loading-status{
-      position:absolute;
-      bottom:calc(var(--layer-scale) * 160px);
-      left:50%;
-      transform:translateX(-50%);
-      padding:calc(var(--layer-scale) * 8px) calc(var(--layer-scale) * 14px);
-      background:rgba(0,0,0,0.45);
-      border:1px solid rgba(255,255,255,0.18);
+      grid-area:lazy;
+      position:relative;
+      margin-top:calc(var(--layer-scale) * -12px);
+      padding:calc(var(--layer-scale) * 8px) calc(var(--layer-scale) * 18px);
+      background:rgba(8,12,30,0.55);
+      border:1px solid rgba(255,255,255,0.14);
       border-radius:999px;
-      font-size:clamp(10px, var(--layer-scale) * 12px, 12px);
+      font-size:clamp(10px, var(--layer-scale) * 12px, 13px);
       letter-spacing:0.05em;
       display:none;
+      box-shadow:0 12px 28px rgba(0,0,0,0.28);
     }
 
     .channel-spinner.loading{ opacity:0.65; }
@@ -252,17 +339,35 @@
 
     @media (max-width:720px){
       body{ background-attachment:scroll; }
+      .console-grid{
+        grid-template-columns:1fr;
+        grid-template-areas:
+          "astral"
+          "lucid"
+          "sky"
+          "fire"
+          "master"
+          "earth"
+          "sea"
+          "eq"
+          "lazy"
+          "actions";
+        gap:clamp(14px, 4vw, 28px);
+      }
+      .console-grid > *{ max-width:calc(var(--layer-scale) * 240px); }
+      .control-knob.large .knob-container{ width:calc(var(--layer-scale) * 170px); height:calc(var(--layer-scale) * 170px); }
+      .control-knob.large .knob-readout{ width:calc(var(--layer-scale) * 190px); }
     }
 
     @media (max-width:560px){
       body{
-        padding:clamp(12px, 6vh, 28px) clamp(10px, 6vw, 18px);
+        padding:calc(max(env(safe-area-inset-top, 0px), clamp(12px, 6vh, 32px))) clamp(10px, 6vw, 18px) calc(max(env(safe-area-inset-bottom, 0px), clamp(18px, 7vh, 36px)));
       }
       .app-container{
-        width:min(100%, calc((100vh - 72px) * 540 / 835));
-        max-width:420px;
+        width:min(100%, 520px);
+        max-width:520px;
         margin:0 auto;
-        max-height:calc(100vh - 72px);
+        aspect-ratio:540 / 835;
       }
     }
 
@@ -280,7 +385,7 @@
     .hint-replay-button{ position:absolute; top:calc(var(--layer-scale) * 14px); right:calc(var(--layer-scale) * 14px); width:calc(var(--layer-scale) * 26px); height:calc(var(--layer-scale) * 26px); border-radius:50%; border:0; background:rgba(255,255,255,0.82); color:#05060a; font-weight:700; font-size:clamp(12px, var(--layer-scale) * 15px, 15px); line-height:calc(var(--layer-scale) * 26px); text-align:center; cursor:pointer; box-shadow:0 4px 12px rgba(0,0,0,0.25); opacity:0.65; transition:opacity 0.2s ease, transform 0.2s ease; z-index:310; }
     .hint-replay-button:hover{ opacity:1; transform:translateY(-1px); }
     .hint-replay-button:focus-visible{ outline:2px solid rgba(70,130,255,0.8); outline-offset:3px; opacity:1; }
-</style></style>
+</style>
 </head>
 <body>
   <div class="app-container">
@@ -299,107 +404,109 @@
         <div class="layer-badge" data-id="layerBadge">Layer</div>
         <div class="tintOverlay" data-id="tintOverlay" aria-hidden="true"></div>
 
-        <div class="loading-indicator" data-id="loadingIndicator" aria-live="polite">
+        <div class="loading-indicator" data-id="loadingIndicator" aria-live="polite" role="button" tabindex="0">
           <div data-id="loadingText">Start SLUMBR</div>
           <div class="progress" aria-hidden="true">
             <div class="progress-bar" data-id="progressBar" style="width:0%"></div>
           </div>
         </div>
 
-        <div class="lazy-loading-status" data-id="lazyStatus" aria-live="polite" hidden>Loading extended library…</div>
-
-        <div class="control-knob astral small">
-          <div class="knob-container small">
-            <input type="range" min="0" max="100" value="60" class="knob-slider small" data-id="astralSlider" aria-label="Astral wet amount">
-            <div class="knob-image small" data-id="astralKnob" style="background-image:url('astral_knob.png');" role="img" aria-label="Astral control"></div>
-          </div>
-          <div class="knob-readout" data-id="astralReadout" aria-live="polite">60</div>
-        </div>
-
-        <div class="control-knob lucid small">
-          <div class="knob-container small">
-            <input type="range" min="0" max="100" value="60" class="knob-slider small" data-id="lucidSlider" aria-label="Lucid modulation depth">
-            <div class="knob-image small" data-id="lucidKnob" style="background-image:url('lucid_knob.png');" role="img" aria-label="Lucid control"></div>
-          </div>
-          <div class="knob-readout" data-id="lucidReadout" aria-live="polite">60</div>
-        </div>
-
-        <div class="channel sky">
-          <div class="channel-content">
-            <div class="knob-container">
-              <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="skySlider" aria-label="Sky channel volume">
-              <div class="knob-image" data-id="skyKnob" style="background-image:url('sky_knob.png');" role="img" aria-label="Sky channel knob"></div>
+        <div class="console-grid">
+          <div class="control-knob astral small">
+            <div class="knob-container small">
+              <input type="range" min="0" max="100" value="60" class="knob-slider small" data-id="astralSlider" aria-label="Astral wet amount">
+              <div class="knob-image small" data-id="astralKnob" style="background-image:url('astral_knob.png');" role="img" aria-label="Astral control"></div>
             </div>
-            <div class="knob-readout" data-id="skyReadout" aria-live="polite">50</div>
-            <select class="channel-spinner" data-id="skySpinner" aria-label="Sky sound">
-              <option value="0">Tempest</option><option value="1">Breeze</option><option value="2">Balmy</option>
-              <option value="3">Temple</option><option value="4">Rain</option><option value="5">Mountains</option><option value="6">Spring</option>
-            </select>
+            <div class="knob-readout" data-id="astralReadout" aria-live="polite">60</div>
           </div>
-        </div>
 
-        <div class="channel fire">
-          <div class="channel-content">
-            <div class="knob-container">
-              <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="fireSlider" aria-label="Fire channel volume">
-              <div class="knob-image" data-id="fireKnob" style="background-image:url('fire_knob.png');" role="img" aria-label="Fire channel knob"></div>
+          <div class="control-knob lucid small">
+            <div class="knob-container small">
+              <input type="range" min="0" max="100" value="60" class="knob-slider small" data-id="lucidSlider" aria-label="Lucid modulation depth">
+              <div class="knob-image small" data-id="lucidKnob" style="background-image:url('lucid_knob.png');" role="img" aria-label="Lucid control"></div>
             </div>
-            <div class="knob-readout" data-id="fireReadout" aria-live="polite">50</div>
-            <select class="channel-spinner" data-id="fireSpinner" aria-label="Fire sound">
-              <option value="0">Hearth</option><option value="1">Forge</option><option value="2">Ember</option>
-              <option value="3">Crackle</option><option value="4">Campfire</option><option value="5">Summer</option><option value="6">Desert</option>
-            </select>
+            <div class="knob-readout" data-id="lucidReadout" aria-live="polite">60</div>
           </div>
-        </div>
 
-        <div class="control-knob master large">
-          <div class="knob-container large">
-            <input type="range" min="0" max="100" value="40" class="knob-slider large" data-id="masterSlider" aria-label="Master volume">
-            <div class="knob-image large" data-id="masterKnob" style="background-image:url('master_knob.png');" role="img" aria-label="Master knob"></div>
-          </div>
-          <div class="knob-readout" data-id="masterReadout" aria-live="polite">40</div>
-        </div>
-
-        <div class="channel earth">
-          <div class="channel-content">
-            <select class="channel-spinner" data-id="earthSpinner" aria-label="Earth sound">
-              <option value="0">Kiln</option><option value="1">Magma</option><option value="2">Crevasse</option>
-              <option value="3">Core</option><option value="4">Forest</option><option value="5">Autumn</option><option value="6">Cave</option>
-            </select>
-            <div class="knob-container">
-              <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="earthSlider" aria-label="Earth channel volume">
-              <div class="knob-image" data-id="earthKnob" style="background-image:url('earth_knob.png');" role="img" aria-label="Earth channel knob"></div>
+          <div class="channel sky">
+            <div class="channel-content">
+              <div class="knob-container">
+                <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="skySlider" aria-label="Sky channel volume">
+                <div class="knob-image" data-id="skyKnob" style="background-image:url('sky_knob.png');" role="img" aria-label="Sky channel knob"></div>
+              </div>
+              <div class="knob-readout" data-id="skyReadout" aria-live="polite">50</div>
+              <select class="channel-spinner" data-id="skySpinner" aria-label="Sky sound">
+                <option value="0">Tempest</option><option value="1">Breeze</option><option value="2">Balmy</option>
+                <option value="3">Temple</option><option value="4">Rain</option><option value="5">Mountains</option><option value="6">Spring</option>
+              </select>
             </div>
-            <div class="knob-readout" data-id="earthReadout" aria-live="polite">50</div>
           </div>
-        </div>
 
-        <div class="channel sea">
-          <div class="channel-content">
-            <select class="channel-spinner" data-id="seaSpinner" aria-label="Sea sound">
-              <option value="0">Stormy</option><option value="1">Brook</option><option value="2">Winter</option>
-              <option value="3">Lake</option><option value="4">Deep</option><option value="5">Glade</option><option value="6">Creek</option>
-            </select>
-            <div class="knob-container">
-              <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="seaSlider" aria-label="Sea channel volume">
-              <div class="knob-image" data-id="seaKnob" style="background-image:url('sea_knob.png');" role="img" aria-label="Sea channel knob"></div>
+          <div class="channel fire">
+            <div class="channel-content">
+              <div class="knob-container">
+                <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="fireSlider" aria-label="Fire channel volume">
+                <div class="knob-image" data-id="fireKnob" style="background-image:url('fire_knob.png');" role="img" aria-label="Fire channel knob"></div>
+              </div>
+              <div class="knob-readout" data-id="fireReadout" aria-live="polite">50</div>
+              <select class="channel-spinner" data-id="fireSpinner" aria-label="Fire sound">
+                <option value="0">Hearth</option><option value="1">Forge</option><option value="2">Ember</option>
+                <option value="3">Crackle</option><option value="4">Campfire</option><option value="5">Summer</option><option value="6">Desert</option>
+              </select>
             </div>
-            <div class="knob-readout" data-id="seaReadout" aria-live="polite">50</div>
           </div>
-        </div>
 
-        <div class="eq-buttons" aria-label="EQ presets">
-          <button class="eq-button eq-white active" data-id="eqWhite" title="White EQ" aria-label="White EQ"></button>
-          <button class="eq-button eq-pink"  data-id="eqPink"  title="Pink EQ"  aria-label="Pink EQ"></button>
-          <button class="eq-button eq-green" data-id="eqGreen" title="Green EQ" aria-label="Green EQ"></button>
-          <button class="eq-button eq-brown" data-id="eqBrown" title="Brown EQ" aria-label="Brown EQ"></button>
-          <button class="eq-button eq-black" data-id="eqBlack" title="Black EQ" aria-label="Black EQ"></button>
-        </div>
+          <div class="control-knob master large">
+            <div class="knob-container large">
+              <input type="range" min="0" max="100" value="40" class="knob-slider large" data-id="masterSlider" aria-label="Master volume">
+              <div class="knob-image large" data-id="masterKnob" style="background-image:url('master_knob.png');" role="img" aria-label="Master knob"></div>
+            </div>
+            <div class="knob-readout" data-id="masterReadout" aria-live="polite">40</div>
+          </div>
 
-        <div class="save-load-buttons">
-          <button class="save-load-button load" data-id="loadButton" aria-label="Load preset" type="button"></button>
-          <button class="save-load-button randomize" data-id="randomizeButton" aria-label="Randomize preset" type="button"></button>
-          <button class="save-load-button save" data-id="saveButton" aria-label="Save preset" type="button"></button>
+          <div class="channel earth">
+            <div class="channel-content">
+              <select class="channel-spinner" data-id="earthSpinner" aria-label="Earth sound">
+                <option value="0">Kiln</option><option value="1">Magma</option><option value="2">Crevasse</option>
+                <option value="3">Core</option><option value="4">Forest</option><option value="5">Autumn</option><option value="6">Cave</option>
+              </select>
+              <div class="knob-container">
+                <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="earthSlider" aria-label="Earth channel volume">
+                <div class="knob-image" data-id="earthKnob" style="background-image:url('earth_knob.png');" role="img" aria-label="Earth channel knob"></div>
+              </div>
+              <div class="knob-readout" data-id="earthReadout" aria-live="polite">50</div>
+            </div>
+          </div>
+
+          <div class="channel sea">
+            <div class="channel-content">
+              <select class="channel-spinner" data-id="seaSpinner" aria-label="Sea sound">
+                <option value="0">Stormy</option><option value="1">Brook</option><option value="2">Winter</option>
+                <option value="3">Lake</option><option value="4">Deep</option><option value="5">Glade</option><option value="6">Creek</option>
+              </select>
+              <div class="knob-container">
+                <input type="range" min="0" max="100" value="50" class="knob-slider" data-id="seaSlider" aria-label="Sea channel volume">
+                <div class="knob-image" data-id="seaKnob" style="background-image:url('sea_knob.png');" role="img" aria-label="Sea channel knob"></div>
+              </div>
+              <div class="knob-readout" data-id="seaReadout" aria-live="polite">50</div>
+            </div>
+          </div>
+
+          <div class="eq-buttons" aria-label="EQ presets">
+            <button class="eq-button eq-white active" data-id="eqWhite" title="White EQ" aria-label="White EQ"></button>
+            <button class="eq-button eq-pink"  data-id="eqPink"  title="Pink EQ"  aria-label="Pink EQ"></button>
+            <button class="eq-button eq-green" data-id="eqGreen" title="Green EQ" aria-label="Green EQ"></button>
+            <button class="eq-button eq-brown" data-id="eqBrown" title="Brown EQ" aria-label="Brown EQ"></button>
+            <button class="eq-button eq-black" data-id="eqBlack" title="Black EQ" aria-label="Black EQ"></button>
+          </div>
+
+          <div class="lazy-loading-status" data-id="lazyStatus" aria-live="polite" hidden>Loading extended library…</div>
+
+          <div class="save-load-buttons">
+            <button class="save-load-button load" data-id="loadButton" aria-label="Load preset" type="button"></button>
+            <button class="save-load-button randomize" data-id="randomizeButton" aria-label="Randomize preset" type="button"></button>
+            <button class="save-load-button save" data-id="saveButton" aria-label="Save preset" type="button"></button>
+          </div>
         </div>
       </div>
     </div>
@@ -465,7 +572,7 @@
       this.wakeLock = null;
 
       this.eqMode = 'white';
-      this.startEvents = ['pointerdown','touchstart','click'];
+      this.startEvents = ['pointerdown','touchstart','click','keydown'];
       this.suppressUserStartCallback = false;
       this.initializingPromise = null;
 
@@ -635,7 +742,7 @@
     addStartListeners(){
       if(!this.startEvents || !this.boundInitializeListener) return;
       this.startEvents.forEach(evt=>{
-        const options = evt === 'click' ? false : { passive:true };
+        const options = (evt === 'click' || evt === 'keydown') ? false : { passive:true };
         this.root.addEventListener(evt, this.boundInitializeListener, options);
       });
     }
@@ -1278,7 +1385,12 @@
     }
 
     initializeEventListeners(){
-      this.boundInitializeListener = async ()=>{
+      this.boundInitializeListener = async (event)=>{
+        if(event && event.type === 'keydown'){
+          const key = (event.key || '').toLowerCase();
+          if(key !== 'enter' && key !== ' ' && key !== 'spacebar'){ return; }
+          event.preventDefault();
+        }
         this.removeStartListeners();
         if(!this.suppressUserStartCallback && typeof this.options.onUserStart === 'function'){
           try{ this.options.onUserStart(this); }
@@ -1532,6 +1644,37 @@
       return SlumbrLayer.sharedAudioContext;
     }
 
+    static ensureAudioUnlocked(){
+      if(SlumbrLayer.audioUnlockRegistered){ return; }
+      SlumbrLayer.audioUnlockRegistered = true;
+
+      const resumeIfNeeded = async ()=>{
+        try{
+          const ctx = SlumbrLayer.getAudioContext();
+          if(ctx.state === 'suspended'){
+            await ctx.resume();
+          }
+          return ctx.state === 'running';
+        }catch(err){
+          console.warn('SLUMBR audio unlock failed:', err);
+          return false;
+        }
+      };
+
+      const events = ['pointerdown','touchstart','mousedown','keydown'];
+      const handle = ()=>{
+        resumeIfNeeded().then(isRunning=>{
+          if(isRunning){
+            events.forEach(evt=> document.removeEventListener(evt, handle, true));
+          }
+        });
+      };
+
+      events.forEach(evt=> document.addEventListener(evt, handle, true));
+      document.addEventListener('visibilitychange', ()=>{ if(document.visibilityState === 'visible'){ resumeIfNeeded(); } });
+      resumeIfNeeded();
+    }
+
     static async fetchSharedAudio(url){
       if(!SlumbrLayer.sharedAudioCache){ SlumbrLayer.sharedAudioCache = new Map(); }
       const cached = SlumbrLayer.sharedAudioCache.get(url);
@@ -1563,6 +1706,7 @@
 
   SlumbrLayer.sharedAudioContext = null;
   SlumbrLayer.sharedAudioCache = new Map();
+  SlumbrLayer.audioUnlockRegistered = false;
 
   class SlumbrLayersManager {
     constructor(){
@@ -1572,10 +1716,13 @@
       this.layers = [];
       this.activeIndex = 0;
 
+      SlumbrLayer.ensureAudioUnlocked();
+
+      const universalStartText = 'Start SLUMBR';
       this.layerConfigs = [
-        { label:'Aurora', baseTint:{ r:120, g:180, b:255 }, baseTintWeight:0.30, theme:'layer-theme-blue', startText:'Start Aurora' },
-        { label:'Verdant', baseTint:{ r:110, g:240, b:170 }, baseTintWeight:0.28, theme:'layer-theme-green', startText:'Start Verdant' },
-        { label:'Crimson', baseTint:{ r:255, g:150, b:160 }, baseTintWeight:0.32, theme:'layer-theme-red', startText:'Start Crimson' }
+        { label:'Aurora', baseTint:{ r:120, g:180, b:255 }, baseTintWeight:0.30, theme:'layer-theme-blue', startText:universalStartText },
+        { label:'Verdant', baseTint:{ r:110, g:240, b:170 }, baseTintWeight:0.28, theme:'layer-theme-green', startText:universalStartText },
+        { label:'Crimson', baseTint:{ r:255, g:150, b:160 }, baseTintWeight:0.32, theme:'layer-theme-red', startText:universalStartText }
       ];
 
       this.layerButtons.forEach((button, idx)=>{


### PR DESCRIPTION
## Summary
- restructure the control surface into a responsive grid so knobs and selectors stay centered without overlapping on desktop or mobile
- refresh the start overlay styling and copy, keeping the "Start SLUMBR" call to action consistent across layers
- add global audio unlock handling and keyboard start support to make mobile initialization reliable

## Testing
- Manual: Loaded the app in a local browser (http://127.0.0.1:8000/index.html)

------
https://chatgpt.com/codex/tasks/task_e_68dbbd9831688325b1f053fa25114474