### PR TITLE
Fix mobile audio stutter while AB partner loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1100,7 +1100,24 @@
         return;
       }
       const Bindex = this.getABIndex(channelName, index);
-      const metaB = ch.audioBuffers[Bindex];
+      let metaB = ch.audioBuffers[Bindex];
+
+      // On slower devices some A/B partner buffers may not be loaded yet. Without
+      // a fallback the crossfade modulator would sweep into silence which sounds
+      // like hard stuttering, especially on mobile. Temporarily mirror the
+      // primary buffer until the partner finishes loading so playback stays
+      // stable.
+      const needsFallback = !metaB || !metaB.buffer || metaB.buffer.duration < 0.05;
+      if(needsFallback){
+        metaB = metaA;
+        if(!this.isSoundLoaded(channelName, Bindex)){
+          this.pendingSpinnerSelections[channelName] = index;
+        }
+      }else{
+        if(this.pendingSpinnerSelections[channelName] === index){
+          delete this.pendingSpinnerSelections[channelName];
+        }
+      }
 
       const now = this.audioContext.currentTime;
       const fade = 0.35;


### PR DESCRIPTION
## Summary
- prevent A/B crossfades from sweeping into silence by mirroring the primary buffer until its partner loads
- queue the requested selection so the true A/B pair is restored as soon as the lazy-loaded buffer is available

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4a3abe608325bac9e12709797369